### PR TITLE
Add `RUST_BACKTRACE=1 cargo run` command usage under different operat…

### DIFF
--- a/contents/basic/result-error/panic.md
+++ b/contents/basic/result-error/panic.md
@@ -26,7 +26,9 @@ note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 以上信息包含了两条重要信息：
 
 - `main` 函数所在的线程崩溃了，发生的代码位置是 `src/main.rs` 中的第2行第5个字符(去除该行前面的空字符)
-- 在使用时加上一个环境变量可以获取更详细的栈展开信息：`RUST_BACKTRACE=1 cargo run`
+- 在使用时加上一个环境变量可以获取更详细的栈展开信息：
+    - Linux/macOS 等UNIX系统： `RUST_BACKTRACE=1 cargo run`
+    - Windows 系统（PowerShell）： `$env:RUST_BACKTRACE=1 ; cargo run`
 
 下面让我们针对第二点进行详细展开讲解。
 
@@ -51,7 +53,7 @@ thread 'main' panicked at 'index out of bounds: the len is 3 but the index is 99
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 ```
 
-好的，现在成功知道问题发生的位置，但是如果我们想知道该问题之前经过了哪些调用环节，该怎么办？那就按照提示使用 `RUST_BACKTRACE=1 cargo run` 来再一次运行程序：
+好的，现在成功知道问题发生的位置，但是如果我们想知道该问题之前经过了哪些调用环节，该怎么办？那就按照提示使用 `RUST_BACKTRACE=1 cargo run` 或 `$env:RUST_BACKTRACE=1 ; cargo run` 来再一次运行程序：
 ```console
 thread 'main' panicked at 'index out of bounds: the len is 3 but the index is 99', src/main.rs:4:5
 stack backtrace:


### PR DESCRIPTION
增加 `RUST_BACKTRACE=1 cargo run` 命令在不同操作系统下的用法：

![image](https://user-images.githubusercontent.com/100085326/155955137-391a1d35-7118-4c51-b9c8-cfca5a764a7d.png)

----

按照文档直接把 `RUST_BACKTRACE=1 cargo run` 放到终端运行发现无作用（Windows 11），后来才了解不同操作系统用法稍有差别，特意补上。