### PR TITLE
Fixed comment some code.

### DIFF
--- a/src/basic/comment.md
+++ b/src/basic/comment.md
@@ -309,14 +309,15 @@ struct MySpecialFormatter;
 如果遇到同名项，可以使用标示类型的方式进行跳转：
 ```rust
 /// 跳转到结构体  [`Foo`](struct@Foo)
-struct Bar;
+pub struct Bar;
 
 /// 跳转到同名函数 [`Foo`](fn@Foo)
-struct Foo {}
+pub struct Foo {}
 
 /// 跳转到同名宏 [`foo!`]
-fn Foo() {}
+pub fn Foo() {}
 
+#[macro_export]
 macro_rules! foo {
   () => {}
 }


### PR DESCRIPTION
在阅读 [2.13. 注释和文档](https://course.rs/basic/comment.html) 章节的 [同名项的跳转](https://course.rs/basic/comment.html#%E5%90%8C%E5%90%8D%E9%A1%B9%E7%9A%84%E8%B7%B3%E8%BD%AC) 栏目时，发现运行 `cargo doc --open` 无法显示。

原因是必须标记为 `pub`，示例代码漏了 `pub` 关键字，另外 `foo!` 也漏了 `#[macro_export]`，修正后的代码为：

```rust
/// 跳转到结构体  [`Foo`](struct@Foo)
pub struct Bar;

/// 跳转到同名函数 [`Foo`](fn@Foo)
pub struct Foo {}

/// 跳转到同名宏 [`foo!`]
pub fn Foo() {}

#[macro_export]
macro_rules! foo {
  () => {}
}
```

预览效果：

![image](https://user-images.githubusercontent.com/100085326/156120892-1a861978-11a1-4a80-b220-e25d9f8570ac.png)

