### PR TITLE
Fix typo in circle-self-ref/circle-reference.md

### DIFF
--- a/src/advance/circle-self-ref/circle-reference.md
+++ b/src/advance/circle-self-ref/circle-reference.md
@@ -211,9 +211,9 @@ fn main() {
         println!("Gadget {} owned by {}", gadget.id, gadget.owner.name);
     }
 
-    // 在 main 函数的最后，gadget_owner，gadget1 和 daget2 都被销毁。
+    // 在 main 函数的最后，gadget_owner，gadget1 和 gadget2 都被销毁。
     // 具体是，因为这几个结构体之间没有了强引用（`Rc<T>`），所以，当他们销毁的时候。
-    // 首先 gadget1 和 gadget2 被销毁。
+    // 首先 gadget2 和 gadget1 被销毁。
     // 然后因为 gadget_owner 的引用数量为 0，所以这个对象可以被销毁了。
     // 循环引用问题也就避免了
 }


### PR DESCRIPTION
1. 修复拼写错误
2. 前面有提到 `Drop` 特征，在注释处我认为显示正确的销毁顺序更为合理