### PR TITLE
Fixed `cargo test` panic!

### DIFF
--- a/src/basic/comment.md
+++ b/src/basic/comment.md
@@ -323,7 +323,7 @@ impl<T> AsyncReceiver<T> {
 除了跳转到标准库，你还可以通过指定具体的路径跳转到自己代码或者其它库的指定项，例如在 `lib.rs` 中添加以下代码：
 
 ```rust
-mod a {
+pub mod a {
     /// `add_one` 返回一个[`Option`]类型
     /// 跳转到[`crate::MySpecialFormatter`]
     pub fn add_one(x: i32) -> Option<i32> {
@@ -331,7 +331,7 @@ mod a {
     }
 }
 
-struct MySpecialFormatter;
+pub struct MySpecialFormatter;
 ```
 
 使用 `crate::MySpecialFormatter` 这种路径就可以实现跳转到 `lib.rs` 中定义的结构体上。
@@ -429,7 +429,7 @@ pub mod utils {
     /// ```rust
     /// use art::utils::mix;
     /// use art::kinds::{PrimaryColor,SecondaryColor};
-    /// assert_eq!(mix(PrimaryColor::Yellow, PrimaryColor::Blue), SecondaryColor::Green)
+    /// assert!(matches!(mix(PrimaryColor::Yellow, PrimaryColor::Blue), SecondaryColor::Green));
     /// ```
     pub fn mix(c1: PrimaryColor, c2: PrimaryColor) -> SecondaryColor {
         SecondaryColor::Green


### PR DESCRIPTION
在 [2.13. 注释和文档 - 一个综合例子](https://course.rs/basic/comment.html#%E4%B8%80%E4%B8%AA%E7%BB%BC%E5%90%88%E4%BE%8B%E5%AD%90) 章节中，该例子测试案例存在两个问题：

![image](https://user-images.githubusercontent.com/100085326/158336944-a42e060d-f9c6-4665-82e5-2c633833dfdb.png)

1.  **枚举类型不能通过 `==` 判断相等性**

![image](https://user-images.githubusercontent.com/100085326/158337283-986c6efc-48db-4c7a-923c-e3a05e46a459.png)

正确的做法应该是使用 `matches!` 模式匹配宏，如：

![image](https://user-images.githubusercontent.com/100085326/158337467-ec7701cf-4bda-4d3a-9feb-65487f5a2ae1.png)

2. **如果有意写错代码，那应该添加 `should_panic` 标识**，如：

![image](https://user-images.githubusercontent.com/100085326/158338058-615fba66-95b2-41cc-8c02-d76ff823cefa.png)


-----------------

最后结论，应该是采取第一种方式，采用 `matches!` 宏方式。
