### PR TITLE
fix: zhihu icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [![Stars Count](https://img.shields.io/github/stars/sunface/rust-course?style=flat)](https://github.com/sunface/rust-by-practice/stargazers) [![Forks Count](https://img.shields.io/github/forks/sunface/rust-course.svg?style=flat)](https://github.com/naaive/orange/network/members)
 <a href="https://www.zhihu.com/column/c_1452781034895446017">
-  <img alt="Sunface | 知乎" height="20px" width="25px" src="https://ss1.baidu.com/6ONXsjip0QIZ8tyhnq/it/u=493147230,3096476255&amp;fm=195&amp;app=88&amp;f=JPEG?w=200&amp;h=200">
+  <img alt="Sunface | 知乎" height="20px" width="20px" src="https://pic1.zhimg.com/v2-b5e4fe8f22096e9e84c5eb58885f448d_xs.jpg?source=78e73102">
 </a>
     
 在线阅读: https://course.rs


### PR DESCRIPTION
一个字的 icon 是刚刚那个链接
两个字的来自 zhihu cdn