### PR TITLE
Fixed deprecated code: `ONCE_INIT`->`Once::new()`

### DIFF
--- a/src/advance/concurrency-with-threads/thread.md
+++ b/src/advance/concurrency-with-threads/thread.md
@@ -475,10 +475,10 @@ fn main() {
 
 ```rust
 use std::thread;
-use std::sync::{Once, ONCE_INIT};
+use std::sync::Once;
 
 static mut VAL: usize = 0;
-static INIT: Once = ONCE_INIT;
+static INIT: Once = Once::new();
 
 fn main() {
     let handle1 = thread::spawn(move || {


### PR DESCRIPTION
在 [3.6.2. 使用多线程 - 只被调用一次的函数](https://course.rs/advance/concurrency-with-threads/thread.html#%E5%8F%AA%E8%A2%AB%E8%B0%83%E7%94%A8%E4%B8%80%E6%AC%A1%E7%9A%84%E5%87%BD%E6%95%B0) 章节中，示例代码使用了 `ONCE_INIT` 来初始化 `INIT`：

![image](https://user-images.githubusercontent.com/100085326/161914827-c9011e07-0648-42bd-baa6-523aaafba9a4.png)

**实际上在 Rust v1.38.0 版本之后，该静态常量已经被标记过时，应该使用 `Once::new()` 代替**：

![image](https://user-images.githubusercontent.com/100085326/161914999-743e2c15-2a52-4b0b-b7a3-df71913dee1a.png)

![image](https://user-images.githubusercontent.com/100085326/161915077-57fbb01f-6356-4a6d-9cd1-0a6a75b9240e.png)

-----

官方标准库说明：https://doc.rust-lang.org/std/sync/constant.ONCE_INIT.html

![image](https://user-images.githubusercontent.com/100085326/161915422-52a0e2d2-ea50-4ca1-8c11-7dde9464d70d.png)

