### PR TITLE
fix: 强制设置lang导致giscus404

### DIFF
--- a/assets/custom.js
+++ b/assets/custom.js
@@ -122,7 +122,7 @@ var initAll = function () {
     document.getElementById("giscus-container").appendChild(divider);
 
     // 选取浏览器默认使用的语言
-    const lang = navigator.language || navigator.userLanguage
+    // const lang = navigator.language || navigator.userLanguage
 
     // 若当前 mdbook 主题为 Light 或 Rust ，则将 giscuz 主题设置为 light
     var theme = "transparent_dark";
@@ -146,7 +146,7 @@ var initAll = function () {
     script.setAttribute("data-emit-metadata", "0");
     script.setAttribute("data-input-position", "top");
     script.setAttribute("data-theme", theme);
-    script.setAttribute("data-lang", lang);
+    // script.setAttribute("data-lang", lang);
     // 预先加载评论会更好，这样用户读到那边时，评论就加载好了
     // script.setAttribute("data-loading", "lazy");
     document.getElementById("giscus-container").appendChild(script);


### PR DESCRIPTION
如果这里设置了data-lang，giscus会拼接url成 `https://giscus.app/{{data-lang-value}}/widget`。如果系统语言是giscus不支持的会404，例如`en-US` (giscus对于en类的，貌似只支持`en`，不支持地区)，去掉让giscus自己检测就好
