### PR TITLE
Change static variable `names` to `NAMES`

### DIFF
--- a/src/advance/global-variable.md
+++ b/src/advance/global-variable.md
@@ -115,10 +115,10 @@ impl Factory{
 
 ```rust
 use std::sync::Mutex;
-static names: Mutex<String> = Mutex::new(String::from("Sunface, Jack, Allen"));
+static NAMES: Mutex<String> = Mutex::new(String::from("Sunface, Jack, Allen"));
 
 fn main() {
-    let v = names.lock().unwrap();
+    let v = NAMES.lock().unwrap();
     println!("{}",v);
 }
 ```
@@ -129,10 +129,10 @@ fn main() {
 error[E0015]: calls in statics are limited to constant functions, tuple structs and tuple variants
  --> src/main.rs:3:42
   |
-3 | static names: Mutex<String> = Mutex::new(String::from("sunface"));
+3 | static NAMES: Mutex<String> = Mutex::new(String::from("sunface"));
 ```
 
-但你又必须在声明时就对`names`进行初始化，此时就陷入了两难的境地。好在天无绝人之路，我们可以使用`lazy_static`包来解决这个问题。
+但你又必须在声明时就对`NAMES`进行初始化，此时就陷入了两难的境地。好在天无绝人之路，我们可以使用`lazy_static`包来解决这个问题。
 
 #### lazy_static
 
@@ -142,11 +142,11 @@ error[E0015]: calls in statics are limited to constant functions, tuple structs 
 use std::sync::Mutex;
 use lazy_static::lazy_static;
 lazy_static! {
-    static ref names: Mutex<String> = Mutex::new(String::from("Sunface, Jack, Allen"));
+    static ref NAMES: Mutex<String> = Mutex::new(String::from("Sunface, Jack, Allen"));
 }
 
 fn main() {
-    let mut v = names.lock().unwrap();
+    let mut v = NAMES.lock().unwrap();
     v.push_str(", Myth");
     println!("{}",v);
 }


### PR DESCRIPTION
`Rust` 语言建议静态变量采用纯大写命名，否则出现警告。

![image](https://user-images.githubusercontent.com/100085326/162692349-4e67a3ed-9998-4124-8c52-ba9df6235d23.png)
