### PR TITLE
Fixed code typo

### DIFF
--- a/src/advance/unsafe/superpowers.md
+++ b/src/advance/unsafe/superpowers.md
@@ -70,7 +70,7 @@ fn get_memory_location() -> (usize, usize) {
   (pointer, length)
 }
 
-// 在制定的内存地址读取字符串
+// 在指定的内存地址读取字符串
 fn get_str_at_location(pointer: usize, length: usize) -> &'static str {
   unsafe { from_utf8_unchecked(from_raw_parts(pointer as *const u8, length)) }
 }

--- a/src/advance/unsafe/superpowers.md
+++ b/src/advance/unsafe/superpowers.md
@@ -177,7 +177,7 @@ fn main() {
 
     let r = &mut v[..];
 
-    let (a, b) = r.split_at_mut(3);
+    let (a, b) = split_at_mut(r, 3);
 
     assert_eq!(a, &mut [1, 2, 3]);
     assert_eq!(b, &mut [4, 5, 6]);
@@ -218,6 +218,17 @@ fn split_at_mut(slice: &mut [i32], mid: usize) -> (&mut [i32], &mut [i32]) {
             slice::from_raw_parts_mut(ptr.add(mid), len - mid),
         )
     }
+}
+
+fn main() {
+    let mut v = vec![1, 2, 3, 4, 5, 6];
+
+    let r = &mut v[..];
+
+    let (a, b) = split_at_mut(r, 3);
+
+    assert_eq!(a, &mut [1, 2, 3]);
+    assert_eq!(b, &mut [4, 5, 6]);
 }
 ```
 


### PR DESCRIPTION
在 [3.9.1 五种兵器 - 用安全抽象包裹 unsafe 代码](https://course.rs/advance/unsafe/superpowers.html#%E7%94%A8%E5%AE%89%E5%85%A8%E6%8A%BD%E8%B1%A1%E5%8C%85%E8%A3%B9-unsafe-%E4%BB%A3%E7%A0%81) 中代码存在调用歧义：

![image](https://user-images.githubusercontent.com/100085326/163373787-fd87d8aa-03d4-43e8-9d16-255bc5310335.png)
