### PR TITLE
fix: typo and add example

### DIFF
--- a/src/async-rust/tokio/select.md
+++ b/src/async-rust/tokio/select.md
@@ -495,7 +495,7 @@ error[E0599]: no method named `poll` found for struct
 
 #### 修改一个分支
 
-下面一起来看看一个稍微复杂一些的 `loop` 循环，首先，我们拥有：
+下面一起来看一个稍微复杂一些的 `loop` 循环，首先，我们拥有：
 
 - 一个消息通道可以传递 `i32` 类型的值
 - 定义在 `i32` 值上的一个异步操作
@@ -566,7 +566,7 @@ thread 'main' panicked at '`async fn` resumed after completion', src/main.rs:1:5
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 ```
 
-`async fn resumed after completion'` 错误的含义是：`async fn` 异步函数在完成后，依然被恢复了(继续使用)。
+```'`async fn` resumed after completion'``` 错误的含义是：`async fn` 异步函数在完成后，依然被恢复了(继续使用)。
 
 回到例子中来，这个错误是由于 `operation` 在它已经调用完成后依然被使用。通常来说，当使用 `.await` 后，调用 `.await` 的值会被消耗掉，因此并不存在这个问题。但是在这例子中，我们在引用上调用 `.await`，因此之后该引用依然可以被使用。
 

--- a/src/async-rust/tokio/stream.md
+++ b/src/async-rust/tokio/stream.md
@@ -275,3 +275,6 @@ stream! {
 ```
 
 嗯，看上去还是相当不错的，代码可读性大幅提升！
+
+<!-- todo generators -->
+是不是发现了一个关键字 `yield` ，他是用来配合生成器使用的。详见[原文](https://doc.rust-lang.org/beta/unstable-book/language-features/generators.html)

--- a/src/async-rust/tokio/stream.md
+++ b/src/async-rust/tokio/stream.md
@@ -180,6 +180,16 @@ got = b"6"
 
 还有一点可以改进的地方：当 `filter` 和 `map` 一起使用时，你往往可以用一个统一的方法来实现 [`filter_map`](https://docs.rs/tokio-stream/0.1.8/tokio_stream/trait.StreamExt.html#method.filter_map)。
 
+```rust
+let messages = subscriber
+    .into_stream()
+    .filter_map(|msg| match msg {
+        Ok(msg) if msg.content.len() == 1 => msg.unwrap().content,
+        _ => None,
+    })
+    .take(3);
+```
+
 想要学习更多的适配器，可以看看 [`StreamExt`](https://docs.rs/tokio-stream/0.1.8/tokio_stream/trait.StreamExt.html) 特征。
 
 ## 实现 Stream 特征


### PR DESCRIPTION
看到了 `yield` 关键字，但是发现似乎没有有关类似的介绍，是否考虑翻译呢？