### PR TITLE
Update Ci: remove actions-rs/cargo@v1

### DIFF
--- a/src/test/ci.md
+++ b/src/test/ci.md
@@ -292,9 +292,7 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
+      - run: cargo check
 
   test:
     name: Test Suite
@@ -306,9 +304,7 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
+      - run: cargo test
 
   fmt:
     name: Rustfmt
@@ -321,10 +317,7 @@ jobs:
           toolchain: stable
           override: true
       - run: rustup component add rustfmt
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+      - run: cargo fmt --all -- --check
 
   clippy:
     name: Clippy
@@ -337,10 +330,7 @@ jobs:
           toolchain: stable
           override: true
       - run: rustup component add clippy
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: -- -D warnings
+      - run: cargo clippy -- -D warnings
 ```
 
 ## 构建


### PR DESCRIPTION
As stated in the document of `actions-rs/cargo@v1`, this action is not required usually, and we can use `cargo` command directly instead. For example, replace

```yaml
- uses: actions-rs/cargo@v1
  with:
    command: fmt
    args: --all -- --check
```

with

```yaml
- run: cargo fmt --all -- --check
```