### PR TITLE
chore: 补充new说明

### DIFF
--- a/src/basic/method.md
+++ b/src/basic/method.md
@@ -20,7 +20,7 @@ struct Circle {
 }
 
 impl Circle {
-    // new是Circle的关联函数，因为它的第一个参数不是self
+    // new是Circle的关联函数，因为它的第一个参数不是self，且new并不是关键字
     // 这种方法往往用于初始化当前结构体的实例
     fn new(x: f64, y: f64, radius: f64) -> Circle {
         Circle {


### PR DESCRIPTION
对于习惯了 `new` 作为关键字的普通程序员，下意识以为 `new` 是关键字；  
致使第一眼看到 `fn new` 以为是强制的写法，遂想补充说明下 `new` 非关键字