### PR TITLE
fix: no method name in too-many-lists

### DIFF
--- a/src/too-many-lists/unsafe-queue/extra-junk.md
+++ b/src/too-many-lists/unsafe-queue/extra-junk.md
@@ -141,10 +141,12 @@ impl<'a, T> Iterator for Iter<'a, T> {
     type Item = &'a T;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.next.map(|node| {
-            self.next = node.next.as_deref();
-            &node.elem
-        })
+        unsafe {
+            self.next.map(|node| {
+                self.next = node.next.as_ref();
+                &node.elem
+            })
+        }
     }
 }
 
@@ -152,10 +154,12 @@ impl<'a, T> Iterator for IterMut<'a, T> {
     type Item = &'a mut T;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.next.take().map(|node| {
-            self.next = node.next.as_deref_mut();
-            &mut node.elem
-        })
+        unsafe {
+            self.next.take().map(|node| {
+                self.next = node.next.as_mut();
+                &mut node.elem
+            })
+        }
     }
 }
 ```


### PR DESCRIPTION
the Iterator implementation in too-many-lists/unsafe-queue/extra-junk.md, `as_ref`/`as_mut` should be used instead of `as_deref`/`as_deref_mut`, and wrap it with unsafe block.