### PR TITLE
更正 appendix/operators 中 *闭合区间* 的示例

### DIFF
--- a/src/appendix/operators.md
+++ b/src/appendix/operators.md
@@ -36,7 +36,7 @@
 | `->`                      | `fn(...) -> type`, <code>&vert;...&vert; -> type</code> | 函数与闭包，返回类型               |                |
 | `.`                       | `expr.ident`                                            | 成员访问                           |                |
 | `..`                      | `..`, `expr..`, `..expr`, `expr..expr`                  | 右半开区间                         | PartialOrd     |
-| `..=`                     | `..`, `expr..`, `..expr`, `expr..expr`                  | 闭合区间                           | PartialOrd     |
+| `..=`                     | `..=expr`, `expr..=expr`                                | 闭合区间                           | PartialOrd     |
 | `..`                      | `..expr`                                                | 结构体更新语法                     |                |
 | `..`                      | `variant(x, ..)`, `struct_type { x, .. }`               | “代表剩余部分”的模式绑定           |                |
 | `...`                     | `expr...expr`                                           | (不推荐使用，用`..=`替代) 闭合区间 |                |


### PR DESCRIPTION
删除了两个不能在在切片中使用的示例: `..=` 和 `expr..=`