### PR TITLE
the demo code can not cache `String` but `&str`

### DIFF
--- a/src/advance/functional-programing/closure.md
+++ b/src/advance/functional-programing/closure.md
@@ -303,7 +303,7 @@ where
 }
 ```
 
-上面的缓存有一个很大的问题：只支持 `u32` 类型的值，若我们想要缓存 `String` 类型，显然就行不通了，因此需要将 `u32` 替换成泛型 `E`，该练习就留给读者自己完成，具体代码可以参考[这里](https://practice.rs/functional-programing/cloure.html#closure-in-structs)
+上面的缓存有一个很大的问题：只支持 `u32` 类型的值，若我们想要缓存 `&str` 类型，显然就行不通了，因此需要将 `u32` 替换成泛型 `E`，该练习就留给读者自己完成，具体代码可以参考[这里](https://practice.rs/functional-programing/cloure.html#closure-in-structs)
 
 ## 捕获作用域中的值
 


### PR DESCRIPTION
文中提到的[例子](https://practice.rs/functional-programing/cloure.html#closure-in-structs)，`E`有`Copy`的type bound，而`String`是没有实现`Copy`的。

```rust
struct Cacher<T,E>
where
    T: Fn(E) -> E,
    E: Copy
{
    query: T,
    value: Option<E>,
}

impl<T,E> Cacher<T,E>
where
    T: Fn(E) -> E,
    E: Copy
{
    fn new(query: T) -> Cacher<T,E> {
        Cacher {
            query,
            value: None,
        }
    }

    fn value(&mut self, arg: E) -> E {
        match self.value {
            Some(v) => v,
            None => {
                let v = (self.query)(arg);
                self.value = Some(v);
                v
            }
        }
    }
}
fn main() {
  
}

#[test]
fn call_with_different_values() {
    let mut c = Cacher::new(|a| a);

    let v1 = c.value(1);
    let v2 = c.value(2);

    assert_eq!(v2, 1);
}
```
