### PR TITLE
Update errors.md

### DIFF
--- a/src/advance/errors.md
+++ b/src/advance/errors.md
@@ -277,7 +277,7 @@ fn main() {
 use std::fmt::{Debug, Display};
 
 pub trait Error: Debug + Display {
-    fn source(&self) -> Option<&(Error + 'static)> { ... }
+    fn source(&self) -> Option<&(dyn Error + 'static)> { ... }
 }
 ```
 


### PR DESCRIPTION
添加缺失的`dyn`关键字