### PR TITLE
用 Github Actions 来部署 Github Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,58 @@
+# This is a  workflow to build and deploy mdbook to github pages
+
+name: Deploy
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  # Build mdBook
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE
+      - uses: actions/checkout@v3
+      # Install mdBook
+      - name: Setup mdBook
+        uses: peaceiris/actions-mdbook@v1
+        with:
+          mdbook-version: 'latest'
+      # Build mdBook
+      - name: Build mdBook
+        run: mdbook build
+      - name: Copy some Files
+        run: |
+          cp ./assets/CNAME ./book/
+          cp ./assets/*.html ./book/
+          cp ./assets/sitemap.xml ./book/
+      # Upload artifact
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          # Artifact name
+          name: book
+          # Path of the directory containing the static assets.
+          path: book/
+
+  # Deploy to github pages
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
+
+    # Deploy to the github-pages environment
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1
+        with:
+          # Name of the artifact to deploy
+          artifact_name: book


### PR DESCRIPTION
我添加了一个github actions配置文件，用来自动化构建mdBook并部署到github pages。
![image](https://user-images.githubusercontent.com/59004461/212287833-33e48db8-d3a4-4b2a-b8e8-ba460ca8d554.png)
通过GitHub官方提供的action，可以避免像`deploy.sh`那样操作git。

如果你打算合并这个PR，你需要做一些准备工作：
- 将仓库的Page设置为由Github Actions部署，如下图所示:
![image](https://user-images.githubusercontent.com/59004461/212288662-28b96553-a0d8-49f1-b0f5-2d20c0e9d1cb.png)
- 添加一条名为`token`的secrets，内容为你生成的github token：
![image](https://user-images.githubusercontent.com/59004461/212289371-d781015e-ce5d-4440-9c52-3a50cca3abf7.png)