### PR TITLE
update thread.md about reference

### DIFF
--- a/src/advance/concurrency-with-threads/thread.md
+++ b/src/advance/concurrency-with-threads/thread.md
@@ -447,14 +447,14 @@ fn main() {
     let pair2 = pair.clone();
 
     thread::spawn(move|| {
-        let &(ref lock, ref cvar) = &*pair2;
+        let (lock, cvar) = &*pair2;
         let mut started = lock.lock().unwrap();
         println!("changing started");
         *started = true;
         cvar.notify_one();
     });
 
-    let &(ref lock, ref cvar) = &*pair;
+    let (lock, cvar) = &*pair;
     let mut started = lock.lock().unwrap();
     while !*started {
         started = cvar.wait(started).unwrap();


### PR DESCRIPTION
[标准库 Condvar Example](https://doc.rust-lang.org/std/sync/struct.Condvar.html#examples)
```rust
// 标准库文档的写法
let (lock, cvar) = &*pair;
```
```rust
// 圣经目前的写法
let &(ref lock, ref cvar) = &*pair;
```
两种写法是等价的，但是圣经里的写法不够简洁，且会让初学者非常疑惑，建议改成标准库文档的写法。
（另外，是不是可以考虑出一期 & 和 ref 的用法总结和区别）