### PR TITLE
fix: page-wrapper overlay navigation

### DIFF
--- a/theme/style.css
+++ b/theme/style.css
@@ -93,6 +93,12 @@ table {
         left: calc(var(--sidebar-width) + var(--page-padding));
     }
 }
+@media only screen and (min-width: 620px) {
+    .sidebar-visible .page-wrapper {
+        transform: none;
+        margin-left: var(--sidebar-width);
+    }
+}
 
 .mobile-nav-chapters {
     width: 40px;


### PR DESCRIPTION
On small screens, page content will overlay navigation