### PR TITLE
Fix incorrect URL in closure.md

### DIFF
--- a/src/advance/functional-programing/closure.md
+++ b/src/advance/functional-programing/closure.md
@@ -303,7 +303,7 @@ where
 }
 ```
 
-上面的缓存有一个很大的问题：只支持 `u32` 类型的值，若我们想要缓存 `&str` 类型，显然就行不通了，因此需要将 `u32` 替换成泛型 `E`，该练习就留给读者自己完成，具体代码可以参考[这里](https://practice.rs/functional-programing/closure.html#closure-in-structs)
+上面的缓存有一个很大的问题：只支持 `u32` 类型的值，若我们想要缓存 `&str` 类型，显然就行不通了，因此需要将 `u32` 替换成泛型 `E`，该练习就留给读者自己完成，具体代码可以参考[这里](https://practice.course.rs/functional-programing/closure.html#closure-in-structs)
 
 ## 捕获作用域中的值
 


### PR DESCRIPTION
fix the incorrect domain name of Rust By Practice
from `practice.rs` to `practice.course.rs`