### PR TITLE
修改位操作示例展示效果

### DIFF
--- a/src/basic/base-type/numbers.md
+++ b/src/basic/base-type/numbers.md
@@ -258,27 +258,33 @@ Rust的位运算基本上和其他语言一样
 
 ```rust
 fn main() {
-    // 二进制为00000010
-    let a:i32 = 2;
+    // 无符号8位整数，二进制为00000010
+    let a: u8 = 2; // 也可以写 let a: u8 = 0b_0000_0010;
+
     // 二进制为00000011
-    let b:i32 = 3;
+    let b: u8 = 3;
 
-    println!("(a & b) value is {}", a & b);
+    // {:08b}：左高右低输出二进制01，不足8位则高位补0
+    println!("a value is        {:08b}", a);
 
-    println!("(a | b) value is {}", a | b);
+    println!("b value is        {:08b}", b);
 
-    println!("(a ^ b) value is {}", a ^ b);
+    println!("(a & b) value is  {:08b}", a & b);
 
-    println!("(!b) value is {} ", !b);
+    println!("(a | b) value is  {:08b}", a | b);
 
-    println!("(a << b) value is {}", a << b);
+    println!("(a ^ b) value is  {:08b}", a ^ b);
 
-    println!("(a >> b) value is {}", a >> b);
+    println!("(!b) value is     {:08b}", !b);
+
+    println!("(a << b) value is {:08b}", a << b);
+
+    println!("(a >> b) value is {:08b}", a >> b);
 
     let mut a = a;
     // 注意这些计算符除了!之外都可以加上=进行赋值 (因为!=要用来判断不等于)
     a <<= b;
-    println!("(a << b) value is {}", a);
+    println!("(a << b) value is {:08b}", a);
 }
 ```
 


### PR DESCRIPTION
修改示例数据类型为u8。原先的i32长度过长不便01二进制展示；且取反操作会一同反转符号位，或许会造成读者疑惑。
展示输出中使用`{:08b}`格式化并对齐，应该更加直观。

修改后的运行效果如下
```powershell
PS D:\pro\rustworks\playground\demo_binop> cargo run
    Finished dev [unoptimized + debuginfo] target(s) in 0.07s
     Running `target\debug\demo_binop.exe`
a value is        00000010
b value is        00000011
(a & b) value is  00000010
(a | b) value is  00000011
(a ^ b) value is  00000001
(!b) value is     11111100
(a << b) value is 00010000
(a >> b) value is 00000000
(a << b) value is 00010000
```