### PR TITLE
style: Fix whitespace in generic.md

### DIFF
--- a/src/basic/trait/generic.md
+++ b/src/basic/trait/generic.md
@@ -304,7 +304,7 @@ fn main() {
     let arr: [i32; 3] = [1, 2, 3];
     display_array(arr);
 
-    let arr: [i32;2] = [1,2];
+    let arr: [i32; 2] = [1, 2];
     display_array(arr);
 }
 ```
@@ -332,7 +332,7 @@ fn main() {
     let arr: [i32; 3] = [1, 2, 3];
     display_array(&arr);
 
-    let arr: [i32;2] = [1,2];
+    let arr: [i32; 2] = [1, 2];
     display_array(&arr);
 }
 ```
@@ -349,7 +349,7 @@ fn main() {
     let arr: [i32; 3] = [1, 2, 3];
     display_array(&arr);
 
-    let arr: [i32;2] = [1,2];
+    let arr: [i32; 2] = [1, 2];
     display_array(&arr);
 }
 ```


### PR DESCRIPTION
添加了空格，与上下文风格保持一致（473行我没有作出修改，但是git把这行标出来了，然而我肉眼没有看出区别）