### PR TITLE
doc: 让文件和mod的对应更清晰

### DIFF
--- a/src/basic/crate-module/module.md
+++ b/src/basic/crate-module/module.md
@@ -351,12 +351,22 @@ error[E0583]: file not found for module `front_of_house`
 - 在 `front_of_house` 目录里创建一个 `mod.rs`，如果你使用的 `rustc` 版本 `1.30` 之前，这是唯一的方法。
 - 在 `front_of_house` **同级**目录里创建一个与模块（目录）**同名**的 rs 文件 `front_of_house.rs`，在新版本里，更建议使用这样的命名方式来避免项目中存在大量同名的 `mod.rs` 文件（ Python 点了个 `踩`）。
 
-而无论是上述哪个方式创建的文件，其内容都是一样的，你需要定义你的子模块（子模块名与文件名相同）：
+如果使用第二种方式，文件结构将如下所示：
+```shell
+src
+├── front_of_house
+│   └── hosting.rs
+├── front_of_house.rs
+└── lib.rs
+```
+
+而无论是上述哪个方式创建的文件，其内容都是一样的，你需要在定义你(`mod.rs` 或 `front_of_house.rs`)的子模块（子模块名与文件名相同）：
 
 ```rust
 pub mod hosting;
 // pub mod serving;
 ```
+
 
 ## 课后练习
 

--- a/src/basic/crate-module/module.md
+++ b/src/basic/crate-module/module.md
@@ -367,7 +367,6 @@ pub mod hosting;
 // pub mod serving;
 ```
 
-
 ## 课后练习
 
 > [Rust By Practice](https://practice-zh.course.rs/crate-module/module.html)，支持代码在线编辑和运行，并提供详细的[习题解答](https://github.com/sunface/rust-by-practice/blob/master/solutions/crate-module/module.md)。


### PR DESCRIPTION
doc: 让文件和mod的对应更清晰

我看的时候有点迷糊，没get到位，看了 https://doc.rust-lang.org/book/ch07-05-separating-modules-into-different-files.html 才理解到位了