### PR TITLE
Update web-server.md

### DIFF
--- a/src/advance-practice1/web-server.md
+++ b/src/advance-practice1/web-server.md
@@ -136,6 +136,7 @@ Request: [
 ```text
 Method Request-URI HTTP-Version
 headers CRLF
+
 message-body
 ```
 
@@ -152,6 +153,7 @@ message-body
 ```text
 HTTP-Version Status-Code Reason-Phrase CRLF
 headers CRLF
+
 message-body
 ```
 
@@ -227,7 +229,7 @@ fn handle_connection(mut stream: TcpStream) {
     let length = contents.len();
 
     let response =
-        format!("{status_line}\r\nContent-Length: {length}\r\n\r\n{contents}");
+        format!("{status_line}\r\nContent-Length: {length}\r\n\r\n\n{contents}");
 
     stream.write_all(response.as_bytes()).unwrap();
 }
@@ -257,7 +259,7 @@ fn handle_connection(mut stream: TcpStream) {
         let length = contents.len();
 
         let response = format!(
-            "{status_line}\r\nContent-Length: {length}\r\n\r\n{contents}"
+            "{status_line}\r\nContent-Length: {length}\r\n\r\n\n{contents}"
         );
 
         stream.write_all(response.as_bytes()).unwrap();
@@ -283,7 +285,7 @@ fn handle_connection(mut stream: TcpStream) {
         let length = contents.len();
 
         let response = format!(
-            "{status_line}\r\nContent-Length: {length}\r\n\r\n{contents}"
+            "{status_line}\r\nContent-Length: {length}\r\n\r\n\n{contents}"
         );
 
         stream.write_all(response.as_bytes()).unwrap();
@@ -324,7 +326,7 @@ fn handle_connection(mut stream: TcpStream) {
     let length = contents.len();
 
     let response =
-        format!("{status_line}\r\nContent-Length: {length}\r\n\r\n{contents}");
+        format!("{status_line}\r\nContent-Length: {length}\r\n\r\n\n{contents}");
 
     stream.write_all(response.as_bytes()).unwrap();
 }


### PR DESCRIPTION
修改请求应答的格式从
```
HTTP-Version Status-Code Reason-Phrase CRLF
headers CRLF
message-body
```
到
```
HTTP-Version Status-Code Reason-Phrase CRLF
headers CRLF

message-body
```
并将 `\r\n{contents}` 修改为 `\r\n\n{contents}`

原因：
当使用原格式的时候，请求网页并不会出现对应的 html 界面。