### PR TITLE
修正Option的排序

### DIFF
--- a/src/basic/match-pattern/option.md
+++ b/src/basic/match-pattern/option.md
@@ -4,8 +4,8 @@
 
 ```rust
 enum Option<T> {
-    Some(T),
     None,
+    Some(T),
 }
 ```
 


### PR DESCRIPTION
由于`None<Some(T)`为`true`(如果`T:PartialOrd`)
所以Option的枚举中，`None`在前，`Some`在后，这个顺序最好不要更改