### PR TITLE
修改 function.md 中的一处小错误

### DIFF
--- a/src/basic/base-type/function.md
+++ b/src/basic/base-type/function.md
@@ -18,7 +18,7 @@ fn add(i: i32, j: i32) -> i32 {
 
 ## 函数要点
 
-- 函数名和变量名使用[蛇形命名法(snake case)](https://course.rs/practice/naming.html)，例如 `fn add_two() -> {}`
+- 函数名和变量名使用[蛇形命名法(snake case)](https://course.rs/practice/naming.html)，例如 `fn add_two() {}`
 - 函数的位置可以随便放，Rust 不关心我们在哪里定义了函数，只要有定义即可
 - 每个函数参数都需要标注类型
 


### PR DESCRIPTION
去掉函数要点部分的例子中 `add_two` 不正确的 `->` 使用，这里的 `add_two` 显然是没有返回值的，应该不用加 `->`