### PR TITLE
fix: typo

### DIFF
--- a/src/basic/trait/advance-trait.md
+++ b/src/basic/trait/advance-trait.md
@@ -88,6 +88,7 @@ trait Container{
     type B;
     fn contains(&self, a: &Self::A, b: &Self::B) -> bool;
 }
+```
 
 ## 默认泛型类型参数
 


### PR DESCRIPTION
这里漏写的 ``` 导致后两行文本被包含进代码块，格式出现错误，故将其补上