### PR TITLE
删除多余代码

### DIFF
--- a/src/advance/async/web-server.md
+++ b/src/advance/async/web-server.md
@@ -324,8 +324,6 @@ async fn test_handle_connection() {
     };
 
     handle_connection(&mut stream).await;
-    let mut buf = [0u8; 1024];
-    stream.read(&mut buf).await.unwrap();
 
     let expected_contents = fs::read_to_string("hello.html").unwrap();
     let expected_response = format!("HTTP/1.1 200 OK\r\n\r\n{}", expected_contents);

--- a/src/advance/async/web-server.md
+++ b/src/advance/async/web-server.md
@@ -323,6 +323,8 @@ async fn test_handle_connection() {
         write_data: Vec::new(),
     };
 
+     // let mut buf = [0u8; 1024];
+    // stream.read(&mut buf).await.unwrap();
     handle_connection(&mut stream).await;
 
     let expected_contents = fs::read_to_string("hello.html").unwrap();


### PR DESCRIPTION
``` rust
 let mut buf = [0u8; 1024];
    stream.read(&mut buf).await.unwrap();
```
stream.read在handle_connection函数里面已经读取过了。另外stream的read方法本来就是mock，不需要验证