### PR TITLE
Fix: Clarify filter example for MyEnum::Foo

### DIFF
--- a/src/basic/match-pattern/match-if-let.md
+++ b/src/basic/match-pattern/match-if-let.md
@@ -318,7 +318,7 @@ fn main() {
 }
 ```
 
-现在如果想对 `v` 进行过滤，只保留类型是 `MyEnum::Foo` 的元素，你可能想这么写：
+现在如果想对 `v` 进行过滤，只保留值是 `MyEnum::Foo` 的元素，你可能想这么写：
 
 ```rust
 v.iter().filter(|x| x == MyEnum::Foo);


### PR DESCRIPTION
Corrected the wording to clarify that the filter retains values of type MyEnum::Foo. Avoiding misunderstanding between "value" and "type" on enum.