### PR TITLE
doc: add the missing semicolon to fix syntax error

### DIFF
--- a/src/basic/match-pattern/pattern-match.md
+++ b/src/basic/match-pattern/pattern-match.md
@@ -201,9 +201,8 @@ if let Some(x) = some_option_value {
 }
 
 // let-else
-let Some(x) = some_option_value else { return; }
+let Some(x) = some_option_value else { return; };
 println!("{}", x);
 ```
 
 在上面的例子中，`if let` 写法里的 `x` 只能在 `if` 分支内使用，而 `let-else` 写法里的 `x` 则可以在 `let` 之外使用。
-


### PR DESCRIPTION
模式匹配章节，模式适用场景，`let-else` 的例子中：

```rs
// if let
if let Some(x) = some_option_value {
    println!("{}", x);
}

// let-else
let Some(x) = some_option_value else { return; }  // Syntax Error: expected SEMICOLON
println!("{}", x);
```
语法错误